### PR TITLE
[codex] Add browser DevTools token capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ build/
 dist/
 *.egg-info/
 tests/fixtures/owa/raw/
+*.token
+.env
+.env.*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ The CLI should favor stable machine interfaces over convenience: JSON by default
 - Backend is OWA service endpoints only, especially `/owa/service.svc`; do not add Microsoft Graph for v1.
 - Treat OWA as unstable and undocumented. Preserve enough raw response/error detail for later inspection, while redacting bearer tokens.
 - Support multiple named connections. Commands that talk to OWA should accept `--connection <name>`.
+- Use company, tenant, or environment specific connection names such as `crayon`, `softwareone`, `swon`, `work`, `personal`, `prod`, or `dev` instead of hidden global account state.
 - Default calendar only for v1. Shared, delegated, and explicit calendar selection are out of scope.
 - Private events are excluded by default unless explicitly included.
 - Recurring events must be handled as expanded occurrences. Refuse likely series/master mutation.
@@ -38,6 +39,20 @@ The CLI should favor stable machine interfaces over convenience: JSON by default
 ## Security Posture
 
 This is a personal-use tool. Plaintext bearer tokens and plaintext token files are acceptable, but tokens must not leak through logs, errors, test fixtures, or normal debug output.
+
+## Preferred Auth Capture Workflow
+
+Prefer browser DevTools capture over manual copy/paste:
+
+```bash
+m365-owa-cli auth extract-token --connection crayon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection softwareone --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection swon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+```
+
+Use `auth bookmarklet` only as a fallback when DevTools capture is unavailable. Never print, paste, commit, or document captured bearer values. Command output should contain only metadata such as connection name, source, host, token file path, and success/failure state.
+
+Connection tokens are local machine state under `~/.config/m365-owa-cli/connections/<connection>.token`; they are not repo artifacts. Do not copy those files into the repository, test fixtures, issues, PRs, screenshots, docs, or logs.
 
 ## Current Status
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ m365-owa-cli capabilities
 m365-owa-cli schema event
 m365-owa-cli auth set-token --connection work
 m365-owa-cli auth bookmarklet --connection work --raw
+m365-owa-cli auth extract-token --connection work --devtools-url http://127.0.0.1:9222 --reload
 m365-owa-cli auth list-connections
 m365-owa-cli events list --connection work --day 2026-04-24
 m365-owa-cli events delete --connection work --id AAMk... --confirm-event-id AAMk...
@@ -28,15 +29,59 @@ Tokens are stored as plaintext files under:
 
 Tests and automation can override the config root with `M365_OWA_CONFIG_DIR`.
 
-## Manual Token Capture
-
-Generate a local-only bookmarklet helper:
+Connection names are the explicit account, company, tenant, or environment selector. Examples:
 
 ```bash
-m365-owa-cli auth bookmarklet --connection work --raw
+m365-owa-cli auth list-connections
+m365-owa-cli events list --connection crayon --day 2026-04-24
+m365-owa-cli events list --connection softwareone --day 2026-04-24
+m365-owa-cli events list --connection swon --day 2026-04-24
+m365-owa-cli events list --connection prod --day 2026-04-24
+```
+
+## Browser Token Capture
+
+Preferred method: watch a DevTools-enabled Edge or Chrome tab and store the first OWA service bearer header it observes. Open Outlook on the web in that browser first:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222
+```
+
+Capture per connection:
+
+```bash
+m365-owa-cli auth extract-token --connection crayon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection softwareone --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection swon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+```
+
+Each command stores a separate local token file:
+
+```text
+~/.config/m365-owa-cli/connections/crayon.token
+~/.config/m365-owa-cli/connections/softwareone.token
+~/.config/m365-owa-cli/connections/swon.token
+```
+
+The command only accepts bearer headers from known Outlook hosts on `/owa/service.svc`; it stores the token locally and emits metadata only. If the capture times out, interact with the open Calendar tab and retry without `--reload`.
+
+## Manual Token Capture Fallback
+
+Use the bookmarklet helper only when DevTools capture is unavailable:
+
+```bash
+m365-owa-cli auth bookmarklet --connection crayon --raw
 ```
 
 Create a browser bookmark with the generated value as the URL, open Outlook on the web, click the bookmarklet, then refresh or open Calendar. If OWA sends an `Authorization: Bearer ...` header to `/owa/service.svc`, the helper displays it for copying into `auth set-token`.
+
+## Opsec
+
+- Do not print, paste, commit, screenshot, or document bearer token values.
+- Do not copy `~/.config/m365-owa-cli/connections/*.token` into this repository.
+- Use `--connection` names like `crayon`, `softwareone`, `swon`, `prod`, `dev`, or another explicit company/environment name so agents never depend on hidden account state.
+- Keep remote debugging bound to the local machine, for example `http://127.0.0.1:9222`.
+- Prefer JSON command output and rely on built-in redaction for errors; do not add ad hoc debug logging around auth headers.
 
 ## Releases
 

--- a/docs/auth-capture.md
+++ b/docs/auth-capture.md
@@ -1,0 +1,104 @@
+# Auth Capture For Agents
+
+This project supports multiple named Microsoft 365 / OWA connections. Treat the connection name as the explicit company, tenant, account, or environment selector.
+
+Good connection names:
+
+- `crayon`
+- `softwareone`
+- `swon`
+- `work`
+- `personal`
+- `prod`
+- `dev`
+- any other company or environment specific text that matches the connection-name rules
+
+Connection names may contain letters, digits, dot, underscore, and dash.
+
+## Preferred Method
+
+Use DevTools browser capture first. It is the preferred auth workflow because it avoids manually copying bearer tokens through chats, shell history, notes, screenshots, and docs.
+
+Start Chrome with a local DevTools port and open Outlook on the web:
+
+```bash
+"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --remote-debugging-port=9222
+```
+
+Then capture and store the token for the intended connection:
+
+```bash
+m365-owa-cli auth extract-token --connection crayon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection softwareone --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection swon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+```
+
+The same pattern works for any company or environment specific connection name:
+
+```bash
+m365-owa-cli auth extract-token --connection <company-or-env> --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+```
+
+If the browser is Edge:
+
+```bash
+m365-owa-cli auth extract-token --connection crayon --browser edge --devtools-url http://127.0.0.1:9222 --reload
+```
+
+## Verify
+
+After capture, test the connection:
+
+```bash
+m365-owa-cli auth test --connection crayon
+m365-owa-cli auth test --connection softwareone
+m365-owa-cli auth test --connection swon
+```
+
+List configured connections without exposing token values:
+
+```bash
+m365-owa-cli auth list-connections
+```
+
+## Storage
+
+Captured tokens are stored outside the repository:
+
+```text
+~/.config/m365-owa-cli/connections/<connection>.token
+```
+
+Examples:
+
+```text
+~/.config/m365-owa-cli/connections/crayon.token
+~/.config/m365-owa-cli/connections/softwareone.token
+~/.config/m365-owa-cli/connections/swon.token
+```
+
+These files are local machine state, not project files.
+
+## Fallback
+
+Use the bookmarklet only when DevTools capture is unavailable:
+
+```bash
+m365-owa-cli auth bookmarklet --connection crayon --raw
+```
+
+Then open Outlook on the web, run the bookmarklet, trigger Calendar traffic, and store the copied value with:
+
+```bash
+m365-owa-cli auth set-token --connection crayon
+```
+
+## Opsec Rules
+
+- Never print, paste, commit, upload, screenshot, or document bearer token values.
+- Never add real tokens to tests, fixtures, README examples, research notes, issues, PRs, commit messages, or chat transcripts.
+- Never copy `~/.config/m365-owa-cli/connections/*.token` into this repository.
+- Keep DevTools capture on local loopback, such as `http://127.0.0.1:9222`.
+- Prefer `auth extract-token` over `auth set-token --token ...`; direct token arguments can land in shell history.
+- Structured output may include connection names, token file paths, source names, hostnames, elapsed time, and success or failure state. It must not include bearer values.
+- If adding new diagnostics, run tests that assert captured or backend bearer strings are redacted from stdout and exceptions.

--- a/docs/research/browser-token-extraction.md
+++ b/docs/research/browser-token-extraction.md
@@ -1,0 +1,82 @@
+# Browser Token Extraction Research
+
+Date: 2026-04-25
+
+## Source Reviewed
+
+- `https://github.com/steipete/sweetlink`, cloned locally to `/tmp/sweetlink`.
+
+## SweetLink Patterns Worth Reusing
+
+SweetLink uses a browser-control model instead of asking users to paste credentials into a CLI:
+
+- It launches or reuses a Chromium-family browser with Chrome DevTools Protocol enabled.
+- It discovers DevTools endpoints through explicit config, saved config, and local port scans.
+- It selects the relevant tab, attaches over DevTools/Puppeteer, and evaluates browser-side state.
+- It can copy cookies from a normal Chrome profile into a controlled profile using `@steipete/sweet-cookie`.
+- It keeps secrets out of normal CLI output and primarily reports session/control metadata.
+
+Relevant files in the cloned repo:
+
+- `/tmp/sweetlink/src/runtime/chrome/launch.ts`
+- `/tmp/sweetlink/src/runtime/chrome/reuse.ts`
+- `/tmp/sweetlink/src/runtime/chrome/cookies.ts`
+- `/tmp/sweetlink/src/runtime/cookies.ts`
+- `/tmp/sweetlink/src/runtime/devtools/cdp.ts`
+
+## Implications For OWA
+
+OWA calendar calls use bearer authorization on requests to `/owa/service.svc`. A CLI cannot read past browser network history through CDP after the fact, so the useful browser integration is a live capture:
+
+1. Attach to an already-open OWA tab in Edge or Chrome through a DevTools endpoint.
+2. Enable CDP network events.
+3. Watch future requests.
+4. Accept only `Authorization: Bearer ...` headers on allowed OWA hosts and `/owa/service.svc`.
+5. Store the captured value through the existing local token store.
+6. Return only redacted metadata in JSON.
+
+Cookie copying is less directly useful for this project because the CLI needs the OWA service bearer header, not a browser cookie jar. It may become useful later if a controlled OWA browser profile is launched automatically and needs to inherit sign-in state from the user profile.
+
+## Current Implementation Direction
+
+The first implementation is intentionally narrow and conservative:
+
+- `m365-owa-cli auth extract-token --connection <name>` now attempts DevTools capture.
+- `--browser edge` remains the default, with `chrome` also accepted because CDP semantics are shared.
+- `--devtools-url` can point at a running endpoint such as `http://127.0.0.1:9222`.
+- If no endpoint is provided, local ports `9222..9322` are scanned.
+- `--reload` can reload the selected OWA tab after attaching to trigger fresh OWA requests.
+- Captured tokens are stored locally and never emitted.
+- DevTools capture is the preferred method for future agent use; bookmarklet/manual copy is the fallback.
+- Use explicit company, tenant, account, or environment connection names such as `crayon`, `softwareone`, `swon`, `prod`, or `dev`.
+
+See `docs/auth-capture.md` for the operational runbook.
+
+## Manual Setup For Interactive Testing
+
+Start a browser with remote debugging, then open Outlook on the web:
+
+```bash
+"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" --remote-debugging-port=9222
+```
+
+Then run:
+
+```bash
+m365-owa-cli auth extract-token --connection crayon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection softwareone --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+m365-owa-cli auth extract-token --connection swon --browser chrome --devtools-url http://127.0.0.1:9222 --reload
+```
+
+If capture times out, keep the command running without `--reload` and interact with Calendar, or use:
+
+```bash
+m365-owa-cli auth bookmarklet --connection work --raw
+```
+
+## Security Notes
+
+- Token values should not be written to docs, tests, logs, or normal command output.
+- Structured errors may include DevTools URLs, tab URLs, and launch hints, but not authorization values.
+- The CDP capture accepts only bearer headers scoped to known OWA hosts and `/owa/service.svc`.
+- Token files under `~/.config/m365-owa-cli/connections/*.token` are local machine state and must not be copied into the repository.

--- a/src/m365_owa_cli/auth.py
+++ b/src/m365_owa_cli/auth.py
@@ -2,28 +2,26 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import time
+from urllib.parse import urlparse
 
 try:
     from .errors import (  # type: ignore
         AUTH_REQUIRED,
-        UNSUPPORTED_OPERATION,
         M365OwaError,
     )
 except ImportError:  # pragma: no cover - fallback for partial scaffolds
-    from .config import (
-        UNSUPPORTED_OPERATION,
-        M365OwaError,
-    )
+    from .config import M365OwaError
     AUTH_REQUIRED = "AUTH_REQUIRED"
 
 from .config import (
-    connection_env_var_name,
     list_connections,
     remove_token,
     resolve_token,
     set_token,
     validate_connection_name,
 )
+from .browser import capture_browser_bearer_token
 from .owa.client import OWAClient
 
 __all__ = [
@@ -222,23 +220,28 @@ def auth_test(
 def extract_token(
     connection: str,
     browser: str = "edge",
+    devtools_url: str | None = None,
+    timeout_seconds: float = 20.0,
+    reload: bool = False,
     config_dir: Path | None = None,
-) -> None:
+) -> dict:
     validate_connection_name(connection)
-    if browser.lower() != "edge":
-        raise M365OwaError(
-            UNSUPPORTED_OPERATION,
-            "Only Edge token extraction is considered for v1.",
-            retryable=False,
-            details={"browser": browser},
-        )
-    raise M365OwaError(
-        UNSUPPORTED_OPERATION,
-        "Browser token extraction is not implemented in this build.",
-        retryable=False,
-        details={
-            "browser": browser,
-            "connection": connection,
-            "env_var": connection_env_var_name(connection),
-        },
+    started_at = time.monotonic()
+    captured = capture_browser_bearer_token(
+        browser=browser,
+        devtools_url=devtools_url,
+        timeout_seconds=timeout_seconds,
+        reload=reload,
     )
+    path = set_token(connection, captured.token, config_dir=config_dir)
+    return {
+        "name": connection,
+        "browser": captured.browser,
+        "stored": True,
+        "token_file": str(path),
+        "source": captured.source,
+        "devtools_url": captured.devtools_url,
+        "page_url": captured.page_url,
+        "captured_host": urlparse(captured.captured_url).hostname,
+        "elapsed_ms": round((time.monotonic() - started_at) * 1000),
+    }

--- a/src/m365_owa_cli/browser.py
+++ b/src/m365_owa_cli/browser.py
@@ -1,0 +1,522 @@
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+import json
+import os
+import secrets
+import socket
+import struct
+import time
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+from .errors import AUTH_REQUIRED, CONFIG_ERROR, M365OwaError, UNSUPPORTED_OPERATION
+
+
+DEVTOOLS_URL_ENV_VAR = "M365_OWA_BROWSER_DEVTOOLS_URL"
+DEFAULT_DEVTOOLS_PORTS = range(9222, 9323)
+SUPPORTED_BROWSERS = {"edge", "chrome"}
+OWA_ALLOWED_HOSTS = {
+    "outlook.cloud.microsoft",
+    "outlook.office.com",
+    "outlook.office365.com",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class BrowserBearerToken:
+    token: str
+    browser: str
+    devtools_url: str
+    page_url: str
+    source: str
+    captured_url: str
+
+
+class _DevToolsWebSocket:
+    def __init__(self, websocket_url: str, *, timeout: float) -> None:
+        parsed = urlparse(websocket_url)
+        if parsed.scheme != "ws" or not parsed.hostname:
+            raise M365OwaError(
+                UNSUPPORTED_OPERATION,
+                "Only local ws:// DevTools endpoints are supported.",
+                details={"websocket_scheme": parsed.scheme or None},
+            )
+        self._host = parsed.hostname
+        self._port = parsed.port or 80
+        self._path = parsed.path or "/"
+        if parsed.query:
+            self._path += f"?{parsed.query}"
+        self._timeout = timeout
+        self._sock: socket.socket | None = None
+
+    def __enter__(self) -> "_DevToolsWebSocket":
+        sock = socket.create_connection((self._host, self._port), timeout=self._timeout)
+        sock.settimeout(self._timeout)
+        key = base64.b64encode(secrets.token_bytes(16)).decode("ascii")
+        request = (
+            f"GET {self._path} HTTP/1.1\r\n"
+            f"Host: {self._host}:{self._port}\r\n"
+            "Upgrade: websocket\r\n"
+            "Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {key}\r\n"
+            "Sec-WebSocket-Version: 13\r\n"
+            "\r\n"
+        )
+        sock.sendall(request.encode("ascii"))
+        response = self._read_http_response(sock)
+        if b" 101 " not in response.split(b"\r\n", 1)[0]:
+            raise M365OwaError(
+                CONFIG_ERROR,
+                "DevTools endpoint did not accept a WebSocket upgrade.",
+                details={"host": self._host, "port": self._port},
+            )
+        self._sock = sock
+        return self
+
+    def __exit__(self, exc_type: object, exc: object, traceback: object) -> None:
+        if self._sock is not None:
+            try:
+                self._send_frame(b"", opcode=0x8)
+            except OSError:
+                pass
+            self._sock.close()
+            self._sock = None
+
+    def send_json(self, payload: dict[str, Any]) -> None:
+        self._send_frame(json.dumps(payload, separators=(",", ":")).encode("utf-8"), opcode=0x1)
+
+    def receive_json(self, *, timeout: float) -> dict[str, Any] | None:
+        sock = self._require_socket()
+        previous_timeout = sock.gettimeout()
+        sock.settimeout(max(timeout, 0.001))
+        try:
+            while True:
+                opcode, payload = self._receive_frame()
+                if opcode == 0x8:
+                    return None
+                if opcode == 0x9:
+                    self._send_frame(payload, opcode=0xA)
+                    continue
+                if opcode not in {0x1, 0x2}:
+                    continue
+                try:
+                    decoded = payload.decode("utf-8")
+                    parsed = json.loads(decoded)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    return None
+                return parsed if isinstance(parsed, dict) else None
+        except socket.timeout:
+            return None
+        finally:
+            sock.settimeout(previous_timeout)
+
+    @staticmethod
+    def _read_http_response(sock: socket.socket) -> bytes:
+        chunks: list[bytes] = []
+        while b"\r\n\r\n" not in b"".join(chunks):
+            chunk = sock.recv(4096)
+            if not chunk:
+                break
+            chunks.append(chunk)
+        return b"".join(chunks)
+
+    def _require_socket(self) -> socket.socket:
+        if self._sock is None:
+            raise RuntimeError("DevTools WebSocket is not connected")
+        return self._sock
+
+    def _send_frame(self, payload: bytes, *, opcode: int) -> None:
+        sock = self._require_socket()
+        first = 0x80 | opcode
+        mask_bit = 0x80
+        length = len(payload)
+        if length < 126:
+            header = struct.pack("!BB", first, mask_bit | length)
+        elif length <= 0xFFFF:
+            header = struct.pack("!BBH", first, mask_bit | 126, length)
+        else:
+            header = struct.pack("!BBQ", first, mask_bit | 127, length)
+        mask = secrets.token_bytes(4)
+        masked = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        sock.sendall(header + mask + masked)
+
+    def _receive_frame(self) -> tuple[int, bytes]:
+        sock = self._require_socket()
+        header = self._recv_exact(sock, 2)
+        first, second = struct.unpack("!BB", header)
+        opcode = first & 0x0F
+        masked = bool(second & 0x80)
+        length = second & 0x7F
+        if length == 126:
+            length = struct.unpack("!H", self._recv_exact(sock, 2))[0]
+        elif length == 127:
+            length = struct.unpack("!Q", self._recv_exact(sock, 8))[0]
+        mask = self._recv_exact(sock, 4) if masked else b""
+        payload = self._recv_exact(sock, length) if length else b""
+        if masked:
+            payload = bytes(byte ^ mask[index % 4] for index, byte in enumerate(payload))
+        return opcode, payload
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, length: int) -> bytes:
+        chunks: list[bytes] = []
+        remaining = length
+        while remaining > 0:
+            chunk = sock.recv(remaining)
+            if not chunk:
+                raise M365OwaError(CONFIG_ERROR, "DevTools WebSocket closed unexpectedly.")
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+
+def capture_browser_bearer_token(
+    *,
+    browser: str = "edge",
+    devtools_url: str | None = None,
+    timeout_seconds: float = 20.0,
+    reload: bool = False,
+) -> BrowserBearerToken:
+    normalized_browser = browser.lower()
+    if normalized_browser not in SUPPORTED_BROWSERS:
+        raise M365OwaError(
+            UNSUPPORTED_OPERATION,
+            "Browser token extraction currently supports Edge and Chrome DevTools endpoints.",
+            details={"browser": browser, "supported_browsers": sorted(SUPPORTED_BROWSERS)},
+        )
+    if timeout_seconds <= 0:
+        raise M365OwaError(
+            CONFIG_ERROR,
+            "Token extraction timeout must be greater than zero.",
+            details={"timeout_seconds": timeout_seconds},
+        )
+
+    endpoints = discover_devtools_endpoints(devtools_url)
+    if not endpoints:
+        raise _capture_failed(
+            "No browser DevTools endpoint was available.",
+            browser=normalized_browser,
+            devtools_url=devtools_url,
+            endpoints=[],
+        )
+
+    candidates: list[dict[str, Any]] = []
+    endpoint_errors: list[dict[str, Any]] = []
+    for endpoint in endpoints:
+        try:
+            tabs = fetch_devtools_tabs(endpoint)
+        except M365OwaError as exc:
+            endpoint_errors.append({"devtools_url": endpoint, "error": exc.to_dict()})
+            continue
+        tab = choose_owa_tab(tabs)
+        if tab is not None:
+            candidates.append({"devtools_url": endpoint, "tab": tab})
+
+    if not candidates:
+        raise _capture_failed(
+            "No open Outlook on the web tab was found in the available DevTools endpoints.",
+            browser=normalized_browser,
+            devtools_url=devtools_url,
+            endpoints=endpoints,
+            endpoint_errors=endpoint_errors,
+        )
+
+    deadline = time.monotonic() + timeout_seconds
+    attempts: list[dict[str, Any]] = []
+    for candidate in candidates:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        endpoint = str(candidate["devtools_url"])
+        tab = candidate["tab"]
+        try:
+            token = _capture_from_tab(
+                browser=normalized_browser,
+                devtools_url=endpoint,
+                tab=tab,
+                timeout_seconds=remaining,
+                reload=reload,
+            )
+            if token is not None:
+                return token
+            attempts.append({"devtools_url": endpoint, "page_url": tab.get("url"), "captured": False})
+        except M365OwaError as exc:
+            attempts.append({"devtools_url": endpoint, "page_url": tab.get("url"), "error": exc.to_dict()})
+
+    raise _capture_failed(
+        "No OWA bearer authorization header was observed before the timeout.",
+        browser=normalized_browser,
+        devtools_url=devtools_url,
+        endpoints=endpoints,
+        attempts=attempts,
+    )
+
+
+def discover_devtools_endpoints(devtools_url: str | None = None) -> list[str]:
+    explicit = devtools_url or os.environ.get(DEVTOOLS_URL_ENV_VAR)
+    if explicit:
+        return [_normalize_devtools_url(explicit)]
+
+    endpoints: list[str] = []
+    with httpx.Client(timeout=0.2) as client:
+        for port in DEFAULT_DEVTOOLS_PORTS:
+            endpoint = f"http://127.0.0.1:{port}"
+            try:
+                response = client.get(f"{endpoint}/json/version")
+            except httpx.HTTPError:
+                continue
+            if response.status_code == 200:
+                endpoints.append(endpoint)
+    return endpoints
+
+
+def fetch_devtools_tabs(devtools_url: str) -> list[dict[str, Any]]:
+    normalized = _normalize_devtools_url(devtools_url)
+    try:
+        response = httpx.get(f"{normalized}/json/list", timeout=2.0)
+    except httpx.HTTPError as exc:
+        raise M365OwaError(
+            CONFIG_ERROR,
+            "Could not query the browser DevTools tab list.",
+            details={"devtools_url": normalized, "error": str(exc)},
+        ) from exc
+    if response.status_code != 200:
+        raise M365OwaError(
+            CONFIG_ERROR,
+            "Browser DevTools tab list returned a non-200 response.",
+            details={"devtools_url": normalized, "status_code": response.status_code},
+        )
+    payload = response.json()
+    if not isinstance(payload, list):
+        raise M365OwaError(
+            CONFIG_ERROR,
+            "Browser DevTools tab list had an unexpected shape.",
+            details={"devtools_url": normalized},
+        )
+    return [entry for entry in payload if isinstance(entry, dict)]
+
+
+def choose_owa_tab(tabs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    for tab in tabs:
+        if tab.get("type") not in {None, "page"}:
+            continue
+        url = tab.get("url")
+        websocket_url = tab.get("webSocketDebuggerUrl")
+        if isinstance(url, str) and isinstance(websocket_url, str) and _is_allowed_owa_url(url):
+            return tab
+    return None
+
+
+def _capture_from_tab(
+    *,
+    browser: str,
+    devtools_url: str,
+    tab: dict[str, Any],
+    timeout_seconds: float,
+    reload: bool,
+) -> BrowserBearerToken | None:
+    websocket_url = tab.get("webSocketDebuggerUrl")
+    page_url = tab.get("url")
+    if not isinstance(websocket_url, str) or not isinstance(page_url, str):
+        return None
+
+    next_id = 0
+    request_urls: dict[str, str] = {}
+    pending_authorizations: dict[str, str] = {}
+
+    def next_command_id() -> int:
+        nonlocal next_id
+        next_id += 1
+        return next_id
+
+    with _DevToolsWebSocket(websocket_url, timeout=min(timeout_seconds, 5.0)) as websocket:
+        network_id = next_command_id()
+        websocket.send_json({"id": network_id, "method": "Network.enable"})
+        _wait_for_command_response(websocket, network_id, deadline=time.monotonic() + min(2.0, timeout_seconds))
+
+        if reload:
+            reload_id = next_command_id()
+            websocket.send_json({"id": reload_id, "method": "Page.reload", "params": {"ignoreCache": False}})
+
+        deadline = time.monotonic() + timeout_seconds
+        while time.monotonic() < deadline:
+            message = websocket.receive_json(timeout=deadline - time.monotonic())
+            if not message:
+                continue
+            captured = _capture_authorization_from_cdp_event(
+                message,
+                browser=browser,
+                devtools_url=devtools_url,
+                page_url=page_url,
+                request_urls=request_urls,
+                pending_authorizations=pending_authorizations,
+            )
+            if captured is not None:
+                return captured
+    return None
+
+
+def _wait_for_command_response(
+    websocket: _DevToolsWebSocket,
+    command_id: int,
+    *,
+    deadline: float,
+) -> None:
+    while time.monotonic() < deadline:
+        message = websocket.receive_json(timeout=deadline - time.monotonic())
+        if not message:
+            continue
+        if message.get("id") == command_id:
+            error = message.get("error")
+            if isinstance(error, dict):
+                raise M365OwaError(
+                    CONFIG_ERROR,
+                    "Browser DevTools command failed.",
+                    details={"command_id": command_id, "error": error.get("message")},
+                )
+            return
+
+
+def _capture_authorization_from_cdp_event(
+    message: dict[str, Any],
+    *,
+    browser: str,
+    devtools_url: str,
+    page_url: str,
+    request_urls: dict[str, str],
+    pending_authorizations: dict[str, str],
+) -> BrowserBearerToken | None:
+    method = message.get("method")
+    params = message.get("params")
+    if not isinstance(method, str) or not isinstance(params, dict):
+        return None
+
+    request_id = params.get("requestId")
+    request_id_text = request_id if isinstance(request_id, str) else None
+
+    if method == "Network.requestWillBeSent":
+        request = params.get("request")
+        if not isinstance(request, dict):
+            return None
+        url = request.get("url")
+        if isinstance(url, str) and request_id_text:
+            request_urls[request_id_text] = url
+            pending = pending_authorizations.pop(request_id_text, None)
+            if pending and _is_target_owa_service_url(url):
+                return BrowserBearerToken(
+                    token=pending,
+                    browser=browser,
+                    devtools_url=devtools_url,
+                    page_url=page_url,
+                    source="devtools_network",
+                    captured_url=url,
+                )
+        headers = request.get("headers")
+        authorization = find_authorization_header(headers)
+        if authorization and isinstance(url, str) and _is_target_owa_service_url(url):
+            return BrowserBearerToken(
+                token=authorization,
+                browser=browser,
+                devtools_url=devtools_url,
+                page_url=page_url,
+                source="devtools_network",
+                captured_url=url,
+            )
+
+    if method == "Network.requestWillBeSentExtraInfo":
+        headers = params.get("headers")
+        authorization = find_authorization_header(headers)
+        if not authorization or not request_id_text:
+            return None
+        url = request_urls.get(request_id_text)
+        if url and _is_target_owa_service_url(url):
+            return BrowserBearerToken(
+                token=authorization,
+                browser=browser,
+                devtools_url=devtools_url,
+                page_url=page_url,
+                source="devtools_network_extra_info",
+                captured_url=url,
+            )
+        pending_authorizations[request_id_text] = authorization
+
+    return None
+
+
+def find_authorization_header(headers: Any) -> str | None:
+    if not isinstance(headers, dict):
+        return None
+    for key, value in headers.items():
+        if str(key).lower() != "authorization":
+            continue
+        value_text = str(value)
+        if value_text.lower().startswith("bearer ") and len(value_text.split(None, 1)) == 2:
+            return value_text
+    return None
+
+
+def _is_allowed_owa_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.hostname in OWA_ALLOWED_HOSTS
+
+
+def _is_target_owa_service_url(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    return parsed.hostname in OWA_ALLOWED_HOSTS and "/owa/service.svc" in parsed.path
+
+
+def _normalize_devtools_url(value: str) -> str:
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise M365OwaError(
+            CONFIG_ERROR,
+            "DevTools URL must be an http(s) URL.",
+            details={"devtools_url": value},
+        )
+    return value.rstrip("/")
+
+
+def _capture_failed(
+    message: str,
+    *,
+    browser: str,
+    devtools_url: str | None,
+    endpoints: list[str],
+    **details: Any,
+) -> M365OwaError:
+    return M365OwaError(
+        AUTH_REQUIRED,
+        message,
+        details={
+            "browser": browser,
+            "devtools_url": devtools_url,
+            "discovered_devtools_urls": endpoints,
+            "env_var": DEVTOOLS_URL_ENV_VAR,
+            "manual_fallback": "m365-owa-cli auth bookmarklet --connection <name> --raw",
+            "launch_hint": _browser_launch_hint(browser),
+            **details,
+        },
+    )
+
+
+def _browser_launch_hint(browser: str) -> str:
+    if browser == "edge":
+        return (
+            "Start Microsoft Edge with remote debugging enabled, open Outlook on the web, then rerun with "
+            "--devtools-url http://127.0.0.1:9222. On macOS the executable is commonly "
+            "'/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge'."
+        )
+    return (
+        "Start Chrome with --remote-debugging-port=9222, open Outlook on the web, then rerun with "
+        "--devtools-url http://127.0.0.1:9222."
+    )

--- a/src/m365_owa_cli/capabilities.py
+++ b/src/m365_owa_cli/capabilities.py
@@ -23,7 +23,7 @@ def capabilities_data() -> dict[str, Any]:
             "token_file",
             "direct_token",
             "bookmarklet",
-            "edge_best_effort",
+            "browser_devtools_best_effort",
         ],
     }
 

--- a/src/m365_owa_cli/cli.py
+++ b/src/m365_owa_cli/cli.py
@@ -361,11 +361,24 @@ def auth_test_command(
 def auth_extract_token(
     connection: str = typer.Option(..., "--connection", help="Connection name."),
     browser: str = typer.Option("edge", "--browser", help="Browser to inspect."),
+    devtools_url: str | None = typer.Option(
+        None,
+        "--devtools-url",
+        help="Chrome DevTools HTTP URL, for example http://127.0.0.1:9222.",
+    ),
+    timeout_seconds: float = typer.Option(20.0, "--timeout", min=0.1, help="Seconds to watch OWA traffic."),
+    reload: bool = typer.Option(False, "--reload", help="Reload the selected OWA tab after attaching."),
     pretty: bool = typer.Option(False, "--pretty", help="Pretty-print JSON."),
 ) -> None:
     try:
-        extract_token(connection, browser=browser)
-        _emit(success_envelope({"extracted": True}, operation="auth.extract-token", connection=connection), pretty=pretty)
+        data = extract_token(
+            connection,
+            browser=browser,
+            devtools_url=devtools_url,
+            timeout_seconds=timeout_seconds,
+            reload=reload,
+        )
+        _emit(success_envelope(data, operation="auth.extract-token", connection=connection), pretty=pretty)
     except M365OwaError as exc:
         _exit_with_error(exc, operation="auth.extract-token", connection=connection, pretty=pretty)
 

--- a/src/m365_owa_cli/schemas.py
+++ b/src/m365_owa_cli/schemas.py
@@ -67,9 +67,9 @@ COMMAND_SCHEMA: list[dict[str, Any]] = [
     },
     {
         "name": "auth extract-token",
-        "summary": "Best-effort browser token extraction.",
+        "summary": "Best-effort browser token extraction through a DevTools-enabled OWA tab.",
         "required_args": ["--connection"],
-        "optional_args": ["--browser"],
+        "optional_args": ["--browser", "--devtools-url", "--timeout", "--reload"],
     },
     {
         "name": "events list",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,10 +11,14 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from m365_owa_cli.auth import auth_test, bookmarklet_payload, extract_token
+from m365_owa_cli.browser import (
+    BrowserBearerToken,
+    choose_owa_tab,
+    find_authorization_header,
+)
 from m365_owa_cli.config import (
     CONFIG_DIR_ENV_VAR,
     CONFIG_ERROR,
-    UNSUPPORTED_OPERATION,
     M365OwaError,
     connection_env_var_name,
     get_config_dir,
@@ -105,14 +109,38 @@ def test_auth_test_probes_owa_when_token_resolves(monkeypatch, tmp_path):
     assert calls == [("work", "file-token"), "probe"]
 
 
-def test_extract_token_placeholder_raises_structured_error(monkeypatch, tmp_path):
+def test_extract_token_stores_captured_browser_token_without_returning_it(monkeypatch, tmp_path):
     monkeypatch.setenv(CONFIG_DIR_ENV_VAR, str(tmp_path))
 
-    with pytest.raises(M365OwaError) as excinfo:
-        extract_token("work")
-    assert excinfo.value.code == UNSUPPORTED_OPERATION
-    assert excinfo.value.details["connection"] == "work"
-    assert excinfo.value.details["env_var"] == connection_env_var_name("work")
+    def fake_capture(**kwargs):
+        assert kwargs == {
+            "browser": "edge",
+            "devtools_url": "http://127.0.0.1:9222",
+            "timeout_seconds": 0.5,
+            "reload": True,
+        }
+        return BrowserBearerToken(
+            token="Bearer captured-secret-token",
+            browser="edge",
+            devtools_url="http://127.0.0.1:9222",
+            page_url="https://outlook.office.com/calendar/view/week",
+            source="devtools_network",
+            captured_url="https://outlook.office.com/owa/service.svc?action=GetCalendarView",
+        )
+
+    monkeypatch.setattr("m365_owa_cli.auth.capture_browser_bearer_token", fake_capture)
+
+    result = extract_token(
+        "work",
+        devtools_url="http://127.0.0.1:9222",
+        timeout_seconds=0.5,
+        reload=True,
+    )
+
+    assert result["stored"] is True
+    assert result["captured_host"] == "outlook.office.com"
+    assert read_token_file("work") == "Bearer captured-secret-token"
+    assert "captured-secret-token" not in json.dumps(result)
 
 
 def test_bookmarklet_payload_is_local_only_and_host_restricted():
@@ -128,3 +156,24 @@ def test_bookmarklet_payload_is_local_only_and_host_restricted():
     assert "XMLHttpRequest" in bookmarklet
     assert "navigator.clipboard.writeText" in bookmarklet
     assert "secret-token-value" not in json.dumps(payload)
+
+
+def test_browser_tab_selection_and_authorization_header_filtering():
+    assert choose_owa_tab(
+        [
+            {
+                "type": "page",
+                "url": "https://example.com",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/page/1",
+            },
+            {
+                "type": "page",
+                "url": "https://outlook.office.com/calendar/view/workweek",
+                "webSocketDebuggerUrl": "ws://127.0.0.1:9222/devtools/page/2",
+            },
+        ]
+    )["url"].startswith("https://outlook.office.com")
+
+    assert find_authorization_header({"Authorization": "Bearer value"}) == "Bearer value"
+    assert find_authorization_header({"authorization": "Basic value"}) is None
+    assert find_authorization_header({"x-authorization": "Bearer value"}) is None

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -10,6 +10,7 @@ from typer.testing import CliRunner
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from m365_owa_cli.cli import app
+from m365_owa_cli.browser import BrowserBearerToken
 from m365_owa_cli.errors import OWA_BACKEND_ERROR, M365OwaError
 
 
@@ -82,6 +83,49 @@ def test_auth_bookmarklet_generates_inspectable_helper():
     assert raw_result.exit_code == 0
     assert raw_result.stdout.startswith("javascript:")
     assert '"ok"' not in raw_result.stdout
+
+
+def test_auth_extract_token_stores_browser_capture_without_leaking(monkeypatch, tmp_path):
+    monkeypatch.setenv("M365_OWA_CONFIG_DIR", str(tmp_path))
+
+    def fake_capture(**kwargs):
+        assert kwargs["browser"] == "edge"
+        assert kwargs["devtools_url"] == "http://127.0.0.1:9222"
+        assert kwargs["timeout_seconds"] == 0.5
+        assert kwargs["reload"] is True
+        return BrowserBearerToken(
+            token="Bearer captured-secret-token",
+            browser="edge",
+            devtools_url="http://127.0.0.1:9222",
+            page_url="https://outlook.office.com/calendar/view/week",
+            source="devtools_network",
+            captured_url="https://outlook.office.com/owa/service.svc?action=GetCalendarView",
+        )
+
+    monkeypatch.setattr("m365_owa_cli.auth.capture_browser_bearer_token", fake_capture)
+
+    result = runner.invoke(
+        app,
+        [
+            "auth",
+            "extract-token",
+            "--connection",
+            "work",
+            "--devtools-url",
+            "http://127.0.0.1:9222",
+            "--timeout",
+            "0.5",
+            "--reload",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = _json(result)
+    assert payload["ok"] is True
+    assert payload["operation"] == "auth.extract-token"
+    assert payload["data"]["stored"] is True
+    assert payload["data"]["captured_host"] == "outlook.office.com"
+    assert "captured-secret-token" not in result.stdout
 
 
 def test_delete_confirmation_failure_exits_before_auth(tmp_path, monkeypatch):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -46,7 +46,7 @@ def test_capabilities_payload_shape() -> None:
         "token_file",
         "direct_token",
         "bookmarklet",
-        "edge_best_effort",
+        "browser_devtools_best_effort",
     ]
 
 
@@ -62,6 +62,7 @@ def test_schema_payload_shapes() -> None:
     assert "events list" in command_names
     assert "schema event" in command_names
     assert "auth bookmarklet" in command_names
+    assert "auth extract-token" in command_names
     assert "events delete" in command_names
 
     assert event_payload["ok"] is True


### PR DESCRIPTION
## Summary

- Add best-effort browser DevTools capture for OWA bearer headers on /owa/service.svc.
- Wire auth extract-token to store captured tokens through the existing named connection token store.
- Document DevTools capture as the preferred agent workflow with company/environment connection names such as crayon, softwareone, and swon.
- Add opsec guardrails for token files, env files, docs, fixtures, and debug output.

## Validation

- uv run --extra dev pytest

## Notes

- Token values are never emitted in normal command output; command responses include metadata only.
- Bookmarklet capture remains available as a fallback when DevTools capture is unavailable.
